### PR TITLE
Added Support for Device-Specific Haptic Profile

### DIFF
--- a/KerbalVR_Mod/GameData/KerbalVR/settings.cfg
+++ b/KerbalVR_Mod/GameData/KerbalVR/settings.cfg
@@ -4,28 +4,62 @@ KerbalVRConfig
 	
 	Haptic
 	{
+		// Valid controller names:
+		//     Default
+		//     Knuckles
+		//     Oculus_Touch
+		//     Vive_Controller
+		//     Vive_Cosmos_Controller
+		//     Holographic_Controller
+
 		enabled = true
-		
-		Level
+
+		Profile
 		{
-			name = Light
-			duration = 0.005
-			frequency = 0.005
-			amplitude = 1.0
+			controller = Default
+
+			Light
+			{
+				duration = 0.005
+				frequency = 0.005
+				amplitude = 1.0
+			}
+			Heavy
+			{
+				duration = 0.1
+				frequency = 100.0
+				amplitude = 1.0
+			}
+			Snap
+			{
+				duration = 0.03
+				frequency = 200.0
+				amplitude = 1.0
+			}
 		}
-		Level
+
+		Profile
 		{
-			name = Heavy
-			duration = 0.1
-			frequency = 100.0
-			amplitude = 1.0
-		}
-		Level
-		{
-			name = Snap
-			duration = 0.03
-			frequency = 200.0
-			amplitude = 1.0
+			controller = Knuckles
+
+			Light
+			{
+				duration = 0.005
+				frequency = 0.005
+				amplitude = 1.0
+			}
+			Heavy
+			{
+				duration = 0.1
+				frequency = 100.0
+				amplitude = 1.0
+			}
+			Snap
+			{
+				duration = 0.03
+				frequency = 200.0
+				amplitude = 1.0
+			}
 		}
 	}
 }

--- a/KerbalVR_Mod/GameData/KerbalVR/settings.cfg
+++ b/KerbalVR_Mod/GameData/KerbalVR/settings.cfg
@@ -4,19 +4,35 @@ KerbalVRConfig
 	
 	Haptic
 	{
-		// Valid controller names:
-		//     Default
-		//     Knuckles
-		//     Oculus_Touch
-		//     Vive_Controller
-		//     Vive_Cosmos_Controller
-		//     Holographic_Controller
+		// Known controller names:
+		//     knuckles
+		//     oculus_touch
+		//     vive_controller
+		//     vive_cosmos_controller
+		//     holographic_controller
+		//
+		// Known HMD names:
+		//     indexhmd
+		//     rift
+		//     vive
+		//     vive_pro
+		//     vive_cosmos
+		//     vive_tracker_camera
+		//     holographic_hmd
+		//
+		// If your device is not listed above, launch the game in VR mode with 
+		// your devices connected. Then find the lines that looks like this in 
+		// the log: 
+		//
+		// [KerbalVR/HardwareUtils] Detected device <deviceId>: <deviceName>
+		//
+		// <deviceName> will be a valid name for use in this config
 
 		enabled = true
 
 		Profile
 		{
-			controller = Default
+			controller = default
 
 			Light
 			{
@@ -40,7 +56,7 @@ KerbalVRConfig
 
 		Profile
 		{
-			controller = Knuckles
+			controller = knuckles
 
 			Light
 			{

--- a/KerbalVR_Mod/KerbalVR/HapticUtils.cs
+++ b/KerbalVR_Mod/KerbalVR/HapticUtils.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.XR;
 using Valve.VR;
 
 namespace KerbalVR
@@ -24,7 +23,7 @@ namespace KerbalVR
 		public class HapticProfile
 		{
 			[PersistentField("controller")]
-			public HardwareUtils.ControllerType controller = HardwareUtils.ControllerType.Default;
+			public string controller = "default";
 			[PersistentField("Light")]
 			public PulseSetting light = new PulseSetting();
 			[PersistentField("Heavy")]
@@ -56,7 +55,7 @@ namespace KerbalVR
 				{
 					Debug.Log($"[KerbalVR/HapticUtils] Profile '{profile.controller}' loaded");
 
-					if (HardwareUtils.controllerType == profile.controller)
+					if (HardwareUtils.devices.Contains(profile.controller.ToLower()))
 					{
 						currentProfile = profile;
 					}
@@ -64,7 +63,7 @@ namespace KerbalVR
 
 				if (currentProfile == null) // no device-specific profile found
 				{
-					HapticProfile defaultProfile = hapticProfiles.FirstOrDefault(x => x.controller == HardwareUtils.ControllerType.Default);
+					HapticProfile defaultProfile = hapticProfiles.FirstOrDefault(x => x.controller.ToLower() == "default");
 					if (defaultProfile != null) // if default profile found
 					{
 						currentProfile = defaultProfile;

--- a/KerbalVR_Mod/KerbalVR/HardwareUtils.cs
+++ b/KerbalVR_Mod/KerbalVR/HardwareUtils.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using Valve.VR;
+using UnityEngine.XR;
+
+namespace KerbalVR
+{
+	public static class HardwareUtils
+	{
+		public enum HMDType
+		{
+			Default,
+			IndexHMD,
+			Rift,
+			Vive,
+			Vive_Pro,
+			Vive_Cosmos,
+			Vive_Tracker_Camera,
+			Holographic_HMD,
+		}
+
+		public enum ControllerType
+		{
+			Default,
+			Knuckles,
+			Oculus_Touch,
+			Vive_Controller,
+			Vive_Cosmos_Controller,
+			Holographic_Controller,
+		}
+
+		public static List<string> devices = new List<string>();
+
+		public static HMDType hmdType = HMDType.Default;
+		public static ControllerType controllerType = ControllerType.Default;
+
+		public static void Init()
+		{
+			uint deviceId = 0;
+			while (true)
+			{
+				string device = SteamVR.instance.GetStringProperty(ETrackedDeviceProperty.Prop_ControllerType_String, deviceId);
+
+				if (device == "<unknown>")
+				{
+					break;
+				}
+
+				devices.Add(device);
+				deviceId++;
+
+				Debug.Log($"[KerbalVR/HardwareUtils] Detected device {deviceId}: {device}");
+			}
+
+			foreach (string device in devices)
+			{
+				if (Enum.TryParse(device, true, out HMDType hmd))
+				{
+					hmdType = hmd;
+				}
+				else if (Enum.TryParse(device, true, out ControllerType controller))
+				{
+					controllerType = controller;
+				}
+			}
+
+			Debug.Log($"[KerbalVR/HardwareUtils] HMD: {hmdType}; Controller: {controllerType}");
+		}
+	}
+}

--- a/KerbalVR_Mod/KerbalVR/HardwareUtils.cs
+++ b/KerbalVR_Mod/KerbalVR/HardwareUtils.cs
@@ -1,42 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using UnityEngine;
 using Valve.VR;
-using UnityEngine.XR;
 
 namespace KerbalVR
 {
 	public static class HardwareUtils
 	{
-		public enum HMDType
-		{
-			Default,
-			IndexHMD,
-			Rift,
-			Vive,
-			Vive_Pro,
-			Vive_Cosmos,
-			Vive_Tracker_Camera,
-			Holographic_HMD,
-		}
-
-		public enum ControllerType
-		{
-			Default,
-			Knuckles,
-			Oculus_Touch,
-			Vive_Controller,
-			Vive_Cosmos_Controller,
-			Holographic_Controller,
-		}
-
 		public static List<string> devices = new List<string>();
-
-		public static HMDType hmdType = HMDType.Default;
-		public static ControllerType controllerType = ControllerType.Default;
 
 		public static void Init()
 		{
@@ -50,25 +20,11 @@ namespace KerbalVR
 					break;
 				}
 
-				devices.Add(device);
+				devices.Add(device.ToLower());
 				deviceId++;
 
 				Debug.Log($"[KerbalVR/HardwareUtils] Detected device {deviceId}: {device}");
 			}
-
-			foreach (string device in devices)
-			{
-				if (Enum.TryParse(device, true, out HMDType hmd))
-				{
-					hmdType = hmd;
-				}
-				else if (Enum.TryParse(device, true, out ControllerType controller))
-				{
-					controllerType = controller;
-				}
-			}
-
-			Debug.Log($"[KerbalVR/HardwareUtils] HMD: {hmdType}; Controller: {controllerType}");
 		}
 	}
 }

--- a/KerbalVR_Mod/KerbalVR/KerbalVR.csproj
+++ b/KerbalVR_Mod/KerbalVR/KerbalVR.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Flight.cs" />
     <Compile Include="Components\KerbalVR_AvionicsComputer.cs" />
     <Compile Include="HapticUtils.cs" />
+    <Compile Include="HardwareUtils.cs" />
     <Compile Include="InteractionCommon\VRFlightStick.cs" />
     <Compile Include="InteractionCommon\VRThrottleLever.cs" />
     <Compile Include="InteractionSystem\KerbalVR_FingertipCollider.cs" />

--- a/KerbalVR_Mod/KerbalVR/KerbalVR_Core.cs
+++ b/KerbalVR_Mod/KerbalVR/KerbalVR_Core.cs
@@ -21,6 +21,7 @@ namespace KerbalVR
 			if (IsVrEnabled)
 			{
 				KerbalVR.Core.InitSteamVRInput();
+				HardwareUtils.Init();
 			}
 
 			//// initialize KerbalVR GameObjects


### PR DESCRIPTION
This closes #117

The device profiles can be set in `KerbalVR/setting.cfg`.

If no matching device-specific profile is found, the default profile will be used.


Example profile:

```cs
...

Haptic
{
	enabled = true

	Profile
	{
		controller = Default

		Light
		{
			duration = 0.005
			frequency = 0.005
			amplitude = 1.0
		}
		Heavy
		{
			duration = 0.1
			frequency = 100.0
			amplitude = 1.0
		}
		Snap
		{
			duration = 0.03
			frequency = 200.0
			amplitude = 1.0
		}
	}

	Profile
	{
		controller = Knuckles

		...
	}

	Profile
	{
		controller = Oculus_Touch

		...
	}
}

...
```

Valid controller names:

-  Default
- Knuckles
- Oculus_Touch
-  Vive_Controller
- Vive_Cosmos_Controller
- Holographic_Controller
