### PR TITLE
Cannot Set Field of View Log Spam Fix

### DIFF
--- a/KerbalVR_Mod/KerbalVR/Addon.cs
+++ b/KerbalVR_Mod/KerbalVR/Addon.cs
@@ -15,9 +15,9 @@ namespace KerbalVR
 		{
 			Utils.Log("Addon Awake");
 
-			ApplyPatches();
-
 			KerbalVR.Core.InitSystems(XRSettings.enabled);
+
+			ApplyPatches();
 
 			// for whatever reason, enabling VR mode during loading makes it super slow (vsync maybe?)
 			KerbalVR.Core.SetVrRunningDesired(false);
@@ -64,6 +64,7 @@ namespace KerbalVR
 		{
 			var harmony = new Harmony("KerbalVR");
 			harmony.PatchAll(Assembly.GetExecutingAssembly());
+			CameraFOVPatch.PatchAll(harmony);
 
 			// I had thought the below code might help with the apparent aliasing issues when using scatterer in vr, but it didn't.
 #if false


### PR DESCRIPTION
This fixes #121.

## Changes:

Move `ApplyPatches` to after `InitSystems` in `Addon.cs` since some patches need to access `IsVrEnabled` but it won't be set until `InitSystems` was called.

Use the manual way of patching the FOV setter since the old way only patches the method specified in the last attribute (`VehiclePhysics.CameraLookAt.Update`).
